### PR TITLE
Исправления Username и прочие фиксы.

### DIFF
--- a/src/components/Breadcrumbs/Breadcrumbs.module.scss
+++ b/src/components/Breadcrumbs/Breadcrumbs.module.scss
@@ -4,6 +4,7 @@
   display: flex;
   flex-direction: row;
   padding-inline-start: 0;
+  padding-left: 0.5rem;
   & li {
     list-style: none;
   }

--- a/src/components/GenericTable/GenericTable.module.scss
+++ b/src/components/GenericTable/GenericTable.module.scss
@@ -9,29 +9,38 @@
   }
 }
 
-.player {
+.username {
+  display: flex;
+  padding-right: 1rem;
+}
+
+.contentWrapper {
   display: flex;
   flex-direction: row;
   align-items: center;
 
   font-size: 0.8rem;
+}
 
+.heroWrapper {
   & a,
-  span {
+  & span {
     text-transform: capitalize;
     max-width: 200px;
     @media (max-width: 600px) {
       max-width: 120px;
     }
   }
+
+  column-gap: 0.45rem;
 }
 
-.username {
-  display: flex;
-  padding-right: 1rem;
+.heroLinkWrapper {
+    display: inline-block;
+    min-width: 1rem;
 }
 
-.anyLink {
+.heroLink {
     display: inline-block; 
     white-space: nowrap;  
     overflow: hidden;
@@ -39,28 +48,34 @@
     margin-top: 0.15rem;
 }
 
-.anyLinkWrapper {
-    display: inline-block;
-    min-width: 1rem;
-}
-
-.linkContainer:hover :global(.link)::before {
-  width: 100%;
-}
-
-.contentContainer {
-  column-gap: 0.45rem;
-}
-
-.itemContainer {
-  align-items: center;
-  display: inline-flex;
+.itemWrapper {  
   column-gap: 0.35rem;
+
+  & a,
+  & span {
+    text-transform: capitalize;
+    max-width: 140px;
+    @media (max-width: 600px) {
+      max-width: 110px;
+    }
+  }
 }
 
-.itemName {
-  //53px ширина иконки ItemIconRaw
-  width: calc(100% - 53px);
+.itemLinkWrapper {
+  display: inline-block;
+  min-width: 1rem;
+}
+
+.itemLink {
+    display: inline-block; 
+    white-space: nowrap;  
+    overflow: hidden;
+    text-overflow: ellipsis;
+    margin-top: 0.15rem;
+}
+
+.linkContainer:hover :global(.globalLinkReference)::before {
+  width: 100%;
 }
 
 .raw {
@@ -71,17 +86,12 @@
 }
 
 .item {
-  display: flex;
-  flex-direction: row;
-  white-space: nowrap;
+  width: 150px;
+  align-items: center;
   
   & img {
     // margin-top: 4px;
     vertical-align: middle;
-  }
-
-  & a {
-    max-width: 160px;
   }
 }
 

--- a/src/components/GenericTable/GenericTable.module.scss
+++ b/src/components/GenericTable/GenericTable.module.scss
@@ -18,16 +18,49 @@
 
   & a,
   span {
-    margin-left: 6px;
     text-transform: capitalize;
-    white-space: nowrap;
     max-width: 200px;
-    overflow: hidden;
-    text-overflow: ellipsis;
     @media (max-width: 600px) {
       max-width: 120px;
     }
   }
+}
+
+.username {
+  display: flex;
+  padding-right: 1rem;
+}
+
+.anyLink {
+    display: inline-block; 
+    white-space: nowrap;  
+    overflow: hidden;
+    text-overflow: ellipsis;
+    margin-top: 0.15rem;
+}
+
+.anyLinkWrapper {
+    display: inline-block;
+    min-width: 1rem;
+}
+
+.linkContainer:hover :global(.link)::before {
+  width: 100%;
+}
+
+.contentContainer {
+  column-gap: 0.45rem;
+}
+
+.itemContainer {
+  align-items: center;
+  display: inline-flex;
+  column-gap: 0.35rem;
+}
+
+.itemName {
+  //53px ширина иконки ItemIconRaw
+  width: calc(100% - 53px);
 }
 
 .raw {
@@ -38,16 +71,13 @@
 }
 
 .item {
+  display: flex;
+  flex-direction: row;
+  white-space: nowrap;
+  
   & img {
     // margin-top: 4px;
     vertical-align: middle;
-  }
-
-  & span {
-    margin-left: 4px;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
   }
 
   & a {
@@ -70,6 +100,7 @@
 }
 
 .sortable {
+  cursor: pointer;
   & svg {
     vertical-align: middle;
   }
@@ -116,11 +147,4 @@
     margin-top: 1px;
     border-color: transparent transparent white transparent;
   }
-}
-
-.oneliner {
-  display: flex;
-  align-items: center;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }

--- a/src/components/GenericTable/GenericTable.tsx
+++ b/src/components/GenericTable/GenericTable.tsx
@@ -105,7 +105,7 @@ const ColRenderer: React.FC<{
     return (
       <td
         style={{ maxWidth: col.maxWidth }}
-        className={col.mobileOmit ? "omit" : undefined}
+        className={cx(col.mobileOmit ? "omit" : undefined, c.username)}
       >
         <UserPreview
           avatarSize={40}
@@ -116,18 +116,22 @@ const ColRenderer: React.FC<{
     );
   } else if (type === ColumnType.Hero) {
     return (
-      <td className={cx({ [c.hero]: !col.noname, omit: col.mobileOmit })}>
+      <td 
+        className={cx({ [c.hero]: !col.noname, omit: col.mobileOmit })}
+        title={heroName(value)}
+      >
         <PageLink
-          link={
-            col.link ? col.link(data) : AppRouter.heroes.hero.index(value).link
-          }
+          className={c.linkContainer}
+          link={col.link ? col.link(data) : AppRouter.heroes.hero.index(value).link}
         >
           {col.noname ? (
             <HeroIcon small hero={value} />
           ) : (
-            <div className={c.player}>
+            <div className={cx(c.player, c.contentContainer)}>
               <HeroIcon small hero={value} />
-              <span>{heroName(value)}</span>
+              <span className={cx(c.anyLinkWrapper, "link")}>
+                <span className={c.anyLink}>{heroName(value)}</span>
+              </span>
             </div>
           )}
         </PageLink>
@@ -147,18 +151,21 @@ const ColRenderer: React.FC<{
   } else if (type === ColumnType.Item) {
     return (
       <td
-        style={{ width: col.noname ? 20 : 120, overflow: "hidden" }}
+        style={{ width: col.noname ? 20 : 120}}
         className={cx(c.item, col.mobileOmit ? "omit" : undefined)}
+        title={itemName(value)}
       >
         {col.noname ? (
           <ItemIcon small item={value} />
         ) : (
           <PageLink
             link={AppRouter.items.item(value).link}
-            className={c.oneliner}
+            className={cx(c.itemContainer, c.linkContainer)}
           >
             <ItemIconRaw small item={value} />
-            <span>{!col.noname && itemName(value)}</span>
+            <span className={cx(c.anyLinkWrapper, c.itemName,"link")}>
+              <span className={c.anyLink} style={{ width: "100%"}}>{!col.noname && itemName(value)}</span>
+            </span>
           </PageLink>
         )}
       </td>
@@ -311,7 +318,7 @@ export const GenericTable: React.FC<Props> = ({
 
             return (
               <th
-                className={cx(c.sortable, {
+                className={cx(sortable ? c.sortable : undefined, {
                   [c.hero]: col.type === ColumnType.Hero,
                   omit: col.mobileOmit,
                 })}

--- a/src/components/GenericTable/GenericTable.tsx
+++ b/src/components/GenericTable/GenericTable.tsx
@@ -111,6 +111,7 @@ const ColRenderer: React.FC<{
           avatarSize={40}
           user={value}
           link={col.link ? col.link(data) : undefined}
+          block
         />
       </td>
     );
@@ -127,10 +128,10 @@ const ColRenderer: React.FC<{
           {col.noname ? (
             <HeroIcon small hero={value} />
           ) : (
-            <div className={cx(c.player, c.contentContainer)}>
+            <div className={cx(c.contentWrapper, c.heroWrapper)}>
               <HeroIcon small hero={value} />
-              <span className={cx(c.anyLinkWrapper, "link")}>
-                <span className={c.anyLink}>{heroName(value)}</span>
+              <span className={cx(c.heroLinkWrapper, "link", "globalLinkReference")}>
+                <span className={c.heroLink}>{heroName(value)}</span>
               </span>
             </div>
           )}
@@ -159,13 +160,15 @@ const ColRenderer: React.FC<{
           <ItemIcon small item={value} />
         ) : (
           <PageLink
+            className={cx(c.linkContainer)}
             link={AppRouter.items.item(value).link}
-            className={cx(c.itemContainer, c.linkContainer)}
           >
-            <ItemIconRaw small item={value} />
-            <span className={cx(c.anyLinkWrapper, c.itemName,"link")}>
-              <span className={c.anyLink} style={{ width: "100%"}}>{!col.noname && itemName(value)}</span>
-            </span>
+            <div className={cx(c.contentWrapper, c.itemWrapper)}>
+              <ItemIconRaw small item={value} />
+              <span className={cx(c.itemLinkWrapper, "link", "globalLinkReference")}>
+                <span className={c.itemLink}>{!col.noname && itemName(value)}</span>
+              </span>
+            </div>
           </PageLink>
         )}
       </td>

--- a/src/components/HeroItemsTable/HeroItemsTable.tsx
+++ b/src/components/HeroItemsTable/HeroItemsTable.tsx
@@ -26,6 +26,7 @@ export const HeroItemsTable: React.FC<IHeroItemsTableProps> = ({
         {
           type: ColumnType.Item,
           name: "Предмет",
+          maxWidth: 120
         },
         {
           type: ColumnType.IntWithBar,

--- a/src/components/HeroPlayersTable/HeroPlayersTable.tsx
+++ b/src/components/HeroPlayersTable/HeroPlayersTable.tsx
@@ -23,7 +23,7 @@ export const HeroPlayersTable: React.FC<IHeroPlayersTableProps> = ({
         {
           name: "Игрок",
           type: ColumnType.Player,
-          maxWidth: 236,
+          maxWidth: 160,
         },
         {
           name: "Матчи",

--- a/src/components/HeroWithItemsHistoryTable/HeroWithItemsHistoryTable.tsx
+++ b/src/components/HeroWithItemsHistoryTable/HeroWithItemsHistoryTable.tsx
@@ -8,6 +8,7 @@ import { colors } from "@/colors";
 import cx from "clsx";
 import { KDABarChart } from "@/components/BarChart/KDABarChart";
 import { ColumnType } from "@/const/tables";
+import { UserDTO } from "@/api/back";
 
 export interface PlayerMatchItem {
   hero: string;
@@ -28,6 +29,8 @@ export interface PlayerMatchItem {
   item3: number;
   item4: number;
   item5: number;
+
+  user: UserDTO
 }
 
 interface IPlayerMatchTableProps {
@@ -35,6 +38,7 @@ interface IPlayerMatchTableProps {
   className?: string;
   withItems?: boolean;
   loading: boolean;
+  showUser?: boolean;
 }
 
 export const HeroWithItemsHistoryTable: React.FC<IPlayerMatchTableProps> = ({
@@ -42,6 +46,7 @@ export const HeroWithItemsHistoryTable: React.FC<IPlayerMatchTableProps> = ({
   className,
   loading,
   withItems,
+  showUser
 }) => {
   return (
     <GenericTable
@@ -49,9 +54,9 @@ export const HeroWithItemsHistoryTable: React.FC<IPlayerMatchTableProps> = ({
       keyProvider={(it) => it[6]}
       columns={[
         {
-          type: ColumnType.Hero,
-          name: "Герой",
-          link: (d) => AppRouter.matches.match(d[6]).link,
+          type: showUser ? ColumnType.Player : ColumnType.Hero,
+          name: showUser ? "Игрок" : "Герой",
+          maxWidth: 150
         },
         {
           type: ColumnType.Raw,
@@ -116,7 +121,7 @@ export const HeroWithItemsHistoryTable: React.FC<IPlayerMatchTableProps> = ({
           : []),
       ]}
       data={data.map((it) => [
-        it.hero,
+        showUser ? it.user: it.hero,
         { won: it.won, timestamp: it.timestamp, matchId: it.matchId },
         [it.mode, it.gameMode],
         it.duration,

--- a/src/components/HeroWithItemsHistoryTable/HeroWithItemsHistoryTable.tsx
+++ b/src/components/HeroWithItemsHistoryTable/HeroWithItemsHistoryTable.tsx
@@ -56,7 +56,7 @@ export const HeroWithItemsHistoryTable: React.FC<IPlayerMatchTableProps> = ({
         {
           type: showUser ? ColumnType.Player : ColumnType.Hero,
           name: showUser ? "Игрок" : "Герой",
-          maxWidth: 150
+          maxWidth: showUser ? 200 : 150
         },
         {
           type: ColumnType.Raw,

--- a/src/components/HeroWithItemsHistoryTable/HeroWithItemsHistoryTable.tsx
+++ b/src/components/HeroWithItemsHistoryTable/HeroWithItemsHistoryTable.tsx
@@ -56,7 +56,7 @@ export const HeroWithItemsHistoryTable: React.FC<IPlayerMatchTableProps> = ({
         {
           type: showUser ? ColumnType.Player : ColumnType.Hero,
           name: showUser ? "Игрок" : "Герой",
-          maxWidth: showUser ? 200 : 150
+          maxWidth: showUser ? 180 : 150
         },
         {
           type: ColumnType.Raw,

--- a/src/components/LiveMatchPreview/LiveMatchPreview.module.scss
+++ b/src/components/LiveMatchPreview/LiveMatchPreview.module.scss
@@ -59,7 +59,6 @@
 
 }
 
-
 .heroIconWrapper {
   position: relative;
 }
@@ -71,22 +70,13 @@
 .playerHeroRow {
   display: flex;
   flex-direction: row;
+  column-gap: 0.5rem;
   align-items: center;
   color: white;
 
   & .player-wrap {
     flex: 1;
     max-width: 175px;
-  }
-
-  & span,
-  a {
-    white-space: nowrap;
-    flex: 1;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    text-decoration: none;
-    transition: 0.3s ease;
   }
 }
 
@@ -121,8 +111,6 @@
     height: 250px;
   }
 }
-
-
 
 .hero {
   width: 30px;
@@ -208,8 +196,6 @@
   }
 }
 
-
-
 .deadIndicator {
   color: black;
   width: 100%;
@@ -220,37 +206,37 @@
     opacity: 1;
 
   }
-
 }
-
-
 
 .level {
   color: white;
   background: rgba(0, 0, 0, 0.7);
   padding: 4px;
-  margin-right: 4px;
   border-radius: 4px;
-  font-size: 14px;
+  font-size: 12px;
   display: block;
-  width: 18px;
+  width: 16px;
+  height: 12px;
   text-align: center;
   flex: unset !important;
+  pointer-events: none;
+
+  position: absolute;
+  right: -5px;
+  bottom: 0px;
 }
 
 .skull {
   position: absolute;
   top: 4px;
-  left: 30px;
+  right: 30px;
   height: 24px;
   width: 24px;
   color: black;
   background: rgba(255, 255, 255, 0.5);
   border-radius: 4px;
-
-
+  pointer-events: none;
 }
-
 
 .watchLive {
   font-size: 1.4rem;
@@ -266,7 +252,6 @@
   }
 }
 
-
 .abandon {
   position: absolute;
   bottom: 0;
@@ -274,7 +259,7 @@
   right: 0;
   display: none;
   width: 100%;
-
+  pointer-events: none;
 
   &__visible {
     display: block;

--- a/src/components/LiveMatchPreview/LiveMatchPreview.module.scss
+++ b/src/components/LiveMatchPreview/LiveMatchPreview.module.scss
@@ -72,11 +72,16 @@
   flex-direction: row;
   column-gap: 0.5rem;
   align-items: center;
+  justify-content: space-between;
   color: white;
 
-  & .player-wrap {
-    flex: 1;
-    max-width: 175px;
+  & .iconPlusName {
+    display: inline-flex;
+    align-items: center;
+    flex: 1; 
+    min-width: 0.5rem;
+    column-gap: 0.5rem;
+    max-width: 15rem;
   }
 }
 

--- a/src/components/LiveMatchPreview/LiveMatchPreview.tsx
+++ b/src/components/LiveMatchPreview/LiveMatchPreview.tsx
@@ -59,7 +59,7 @@ const TeamListTableEntry = (slot: MatchSlotInfo) => {
               src="/abandon.png"
             />
           </div>
-          <Username user={slot.user} />
+          <Username user={slot.user} block />
           <KDATableData kills={0} deaths={0} assists={0} forceInteger />
         </div>
         <div className={c.itemRow}>
@@ -74,7 +74,8 @@ const TeamListTableEntry = (slot: MatchSlotInfo) => {
   return (
     <div key={slot.user.steamId} className={c.playerRow}>
       <div className={cx(c.playerHeroRow, hero.respawnTime > 0 && c.dead)}>
-        <div className={c.heroIconWrapper} title={heroName(hero.hero)}>
+        <div className={c.iconPlusName}>
+          <div className={c.heroIconWrapper} title={heroName(hero.hero)}>
           <PageLink link={ AppRouter.heroes.hero.index(hero.hero).link}>
             <HeroIcon small hero={hero.hero} />
           </PageLink>
@@ -95,8 +96,9 @@ const TeamListTableEntry = (slot: MatchSlotInfo) => {
             alt={`Player ${slot.user.name} abandoned`}
             src="/abandon.png"
           />
+          </div>
+          <Username user={slot.user} block />
         </div>
-        <Username user={slot.user}/>
         <KDATableData
           kills={hero.kills}
           deaths={hero.deaths}

--- a/src/components/LiveMatchPreview/LiveMatchPreview.tsx
+++ b/src/components/LiveMatchPreview/LiveMatchPreview.tsx
@@ -19,11 +19,12 @@ import {
 import { AppRouter } from "@/route";
 import { KDATableData } from "@/components/GenericTable/GenericTable";
 import cx from "clsx";
-import { shortName } from "@/util/heroName";
+import heroName, { shortName } from "@/util/heroName";
 import { watchCmd } from "@/util/urls";
 import { TbGrave2 } from "react-icons/tb";
 import { remapNumber } from "@/util/math";
 import { iterateItems } from "@/util";
+import { Username } from "../Username/Username";
 
 interface ILiveMatchPreviewProps {
   match: LiveMatchDto;
@@ -58,16 +59,7 @@ const TeamListTableEntry = (slot: MatchSlotInfo) => {
               src="/abandon.png"
             />
           </div>
-          {slot.user.steamId.length <= 2 ? (
-            <span>{"Бот"}</span>
-          ) : (
-            <PageLink
-              className={"link"}
-              link={AppRouter.players.player.index(slot.user.steamId).link}
-            >
-              <span>{slot.user.name}</span>
-            </PageLink>
-          )}
+          <Username user={slot.user} />
           <KDATableData kills={0} deaths={0} assists={0} forceInteger />
         </div>
         <div className={c.itemRow}>
@@ -82,12 +74,15 @@ const TeamListTableEntry = (slot: MatchSlotInfo) => {
   return (
     <div key={slot.user.steamId} className={c.playerRow}>
       <div className={cx(c.playerHeroRow, hero.respawnTime > 0 && c.dead)}>
-        <div className={c.heroIconWrapper}>
-          <HeroIcon small hero={hero.hero} />
+        <div className={c.heroIconWrapper} title={heroName(hero.hero)}>
+          <PageLink link={ AppRouter.heroes.hero.index(hero.hero).link}>
+            <HeroIcon small hero={hero.hero} />
+          </PageLink>
           <TbGrave2
             style={{ opacity: hero.respawnTime > 0 ? 1 : 0 }}
             className={c.skull}
           />
+          <span className={c.level}>{hero.level}</span>
           <img
             className={cx(
               c.abandon,
@@ -101,17 +96,7 @@ const TeamListTableEntry = (slot: MatchSlotInfo) => {
             src="/abandon.png"
           />
         </div>
-        <span className={c.level}>{hero.level}</span>
-        {hero.bot ? (
-          <span>{"Бот"}</span>
-        ) : (
-          <PageLink
-            className={"link"}
-            link={AppRouter.players.player.index(slot.user.steamId).link}
-          >
-            <span>{slot.user.name}</span>
-          </PageLink>
-        )}
+        <Username user={slot.user}/>
         <KDATableData
           kills={hero.kills}
           deaths={hero.deaths}

--- a/src/components/MatchTeamTable/MatchTeamTable.module.scss
+++ b/src/components/MatchTeamTable/MatchTeamTable.module.scss
@@ -2,6 +2,7 @@
 
 .heroWithLevel {
   position: relative;
+  width: fit-content;
 
   & .abandon {
     position: absolute;
@@ -10,6 +11,7 @@
     right: 0;
     display: none;
     width: 100%;
+    pointer-events: none;
 
     &__visible {
       display: block;
@@ -17,14 +19,19 @@
   }
 }
 
+.underline {
+  text-decoration: underline;
+}
+
 .level {
   color: white;
   position: absolute;
-  right: 0px;
+  right: -5px;
   bottom: 0px;
   background: rgba(0, 0, 0, 0.7);
   padding: 4px;
   border-radius: 4px;
+  pointer-events: none;
 }
 
 .gold {
@@ -68,8 +75,8 @@
   }
 }
 
-.calibration {
-}
+// .calibration {
+// }
 
 .commend {
   font-size: 1rem;

--- a/src/components/MatchTeamTable/MatchTeamTable.module.scss
+++ b/src/components/MatchTeamTable/MatchTeamTable.module.scss
@@ -39,17 +39,9 @@
 }
 
 .fixedWidth {
-  width: 300px;
-
-  @media (max-width: 600px) {
-    margin-left: 6px;
-    text-transform: capitalize;
-    white-space: nowrap;
-    width: 200px;
-    max-width: 130px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
+  width: 10rem;
+  display: flex;
+  align-items: center;
 }
 
 .mobileHidden {

--- a/src/components/MatchTeamTable/MatchTeamTable.tsx
+++ b/src/components/MatchTeamTable/MatchTeamTable.tsx
@@ -20,6 +20,8 @@ import { observer } from "mobx-react-lite";
 import { useStore } from "@/store";
 import { GiFist } from "react-icons/gi";
 import { GrActions } from "react-icons/gr";
+import { Username } from "../Username/Username";
+import heroName from "@/util/heroName";
 
 interface IMatchTeamTableProps {
   players: PlayerInMatchDto[];
@@ -28,6 +30,7 @@ interface IMatchTeamTableProps {
   reportableSteamIds: string[];
   onFeedback: (plr: PlayerInMatchDto) => void;
   onReport: (plr: PlayerInMatchDto) => void;
+  globalMaxValues?: Record<string, number>;
 }
 
 export const MatchTeamTable: React.FC<IMatchTeamTableProps> = observer(
@@ -38,8 +41,42 @@ export const MatchTeamTable: React.FC<IMatchTeamTableProps> = observer(
     reportableSteamIds,
     onFeedback,
     onReport,
+    globalMaxValues,
   }) => {
     const { hasReports } = useStore().auth;
+
+     const maxValues = globalMaxValues ?? useMemo(() => {
+      const mx: Record<string, number> = {
+        gpm: 0,
+        xpm: 0,
+        lastHits: 0,
+        denies: 0,
+        kills: 0,
+        deaths: 0,
+        assists: 0,
+        heroDamage: 0,
+        heroHealing: 0,
+        towerDamage: 0,
+        gold: 0,
+      };
+      for (const p of players) {
+        mx.gpm = Math.max(mx.gpm, p.gpm);
+        mx.xpm = Math.max(mx.xpm, p.xpm);
+        mx.lastHits = Math.max(mx.lastHits, p.lastHits);
+        mx.denies = Math.max(mx.denies, p.denies);
+        mx.kills = Math.max(mx.kills, p.kills);
+        mx.deaths = Math.max(mx.deaths, p.deaths);
+        mx.assists = Math.max(mx.assists, p.assists);
+        mx.heroDamage = Math.max(mx.heroDamage, p.heroDamage);
+        mx.heroHealing = Math.max(mx.heroHealing, p.heroHealing);
+        mx.towerDamage = Math.max(mx.towerDamage, p.towerDamage);
+        const goldValue = Math.round(
+          p.gold || Math.round((p.gpm * duration) / 60) * 0.6
+        );
+        mx.gold = Math.max(mx.gold, goldValue);
+      }
+      return mx;
+    }, [players, duration]);
 
     const sortedPlayers = useMemo(
       () => [...players].sort((a, b) => a.partyIndex - b.partyIndex),
@@ -191,7 +228,7 @@ export const MatchTeamTable: React.FC<IMatchTeamTableProps> = observer(
             return (
               <tr key={player.user.steamId}>
                 <td>
-                  <div className={cx(c.heroWithLevel)}>
+                  <div className={cx(c.heroWithLevel)} title={heroName(player.hero)}>
                     {shouldDisplay && (
                       <span className={c.party__indicator_root}>
                         <span
@@ -205,11 +242,7 @@ export const MatchTeamTable: React.FC<IMatchTeamTableProps> = observer(
                         />
                       </span>
                     )}
-                    <PageLink
-                      link={
-                        AppRouter.players.player.index(player.user.steamId).link
-                      }
-                    >
+                    <PageLink link={AppRouter.heroes.hero.index(player.hero).link}>
                       <HeroIcon hero={player.hero} />
                     </PageLink>
                     <img
@@ -224,14 +257,7 @@ export const MatchTeamTable: React.FC<IMatchTeamTableProps> = observer(
                   </div>
                 </td>
                 <td className={c.fixedWidth}>
-                  <PageLink
-                    className={"link"}
-                    link={
-                      AppRouter.players.player.index(player.user.steamId).link
-                    }
-                  >
-                    {player.user.steamId.length > 2 ? player.user.name : "Бот"}
-                  </PageLink>
+                  <Username user={player.user} />
                 </td>
                 <td
                   className={cx(
@@ -239,7 +265,9 @@ export const MatchTeamTable: React.FC<IMatchTeamTableProps> = observer(
                     hc.includes("GPM") ? c.mobileHidden : undefined,
                   )}
                 >
-                  {player.gpm}/{player.xpm}
+                  <span className={cx(player.gpm > 0 && player.gpm === maxValues.gpm && c.underline)}>{player.gpm}</span>
+                  /
+                  <span className={cx(player.xpm > 0 && player.xpm === maxValues.xpm && c.underline)}>{player.xpm}</span>
                 </td>
                 <td
                   className={cx(
@@ -247,13 +275,16 @@ export const MatchTeamTable: React.FC<IMatchTeamTableProps> = observer(
                     hc.includes("LH") ? c.mobileHidden : undefined,
                   )}
                 >
-                  {player.lastHits}/{player.denies}
+                  <span className={cx(player.lastHits > 0 && player.lastHits === maxValues.lastHits && c.underline)}>{player.lastHits}</span>
+                  /
+                  <span className={cx(player.denies > 0 && player.denies === maxValues.denies && c.underline)}>{player.denies}</span>
                 </td>
 
                 <td
                   className={cx(
                     "middle",
                     hc.includes("K") ? c.mobileHidden : undefined,
+                    player.kills > 0 && player.kills === maxValues.kills && c.underline
                   )}
                 >
                   {player.kills}
@@ -262,6 +293,7 @@ export const MatchTeamTable: React.FC<IMatchTeamTableProps> = observer(
                   className={cx(
                     "middle",
                     hc.includes("D") ? c.mobileHidden : undefined,
+                    player.deaths > 0 && player.deaths === maxValues.deaths && c.underline
                   )}
                 >
                   {player.deaths}
@@ -270,6 +302,7 @@ export const MatchTeamTable: React.FC<IMatchTeamTableProps> = observer(
                   className={cx(
                     "middle",
                     hc.includes("A") ? c.mobileHidden : undefined,
+                    player.assists > 0 && player.assists === maxValues.assists && c.underline
                   )}
                 >
                   {player.assists}
@@ -279,6 +312,7 @@ export const MatchTeamTable: React.FC<IMatchTeamTableProps> = observer(
                   className={cx(
                     "middle",
                     hc.includes("HD") ? c.mobileHidden : undefined,
+                    player.heroDamage > 0 && player.heroDamage === maxValues.heroDamage && c.underline
                   )}
                 >
                   <NumberFormat number={player.heroDamage} />
@@ -287,6 +321,7 @@ export const MatchTeamTable: React.FC<IMatchTeamTableProps> = observer(
                   className={cx(
                     "middle",
                     hc.includes("HH") ? c.mobileHidden : undefined,
+                    player.heroHealing > 0 && player.heroHealing === maxValues.heroHealing && c.underline
                   )}
                 >
                   <NumberFormat number={player.heroHealing} />
@@ -295,6 +330,7 @@ export const MatchTeamTable: React.FC<IMatchTeamTableProps> = observer(
                   className={cx(
                     "middle",
                     hc.includes("TD") ? c.mobileHidden : undefined,
+                    player.towerDamage > 0 && player.towerDamage === maxValues.towerDamage && c.underline
                   )}
                 >
                   <NumberFormat number={player.towerDamage} />
@@ -303,6 +339,7 @@ export const MatchTeamTable: React.FC<IMatchTeamTableProps> = observer(
                   className={cx(
                     c.gold,
                     hc.includes("NW") ? c.mobileHidden : undefined,
+                    player.gold > 0 && player.gold === maxValues.gold && c.underline
                   )}
                 >
                   <NumberFormat

--- a/src/components/MatchTeamTable/MatchTeamTable.tsx
+++ b/src/components/MatchTeamTable/MatchTeamTable.tsx
@@ -256,8 +256,10 @@ export const MatchTeamTable: React.FC<IMatchTeamTableProps> = observer(
                     <span className={c.level}>{player.level}</span>
                   </div>
                 </td>
-                <td className={c.fixedWidth}>
-                  <Username user={player.user} />
+                <td>
+                  <div className={c.fixedWidth}>
+                    <Username user={player.user} block />
+                  </div>
                 </td>
                 <td
                   className={cx(

--- a/src/components/Message/Message.module.scss
+++ b/src/components/Message/Message.module.scss
@@ -19,6 +19,7 @@
   gap: 4px;
   align-items: center;
   padding-right: 8px;
+  max-height: 1rem;
 
   & svg {
     vertical-align: middle;
@@ -30,6 +31,7 @@
   flex: 1;
   justify-content: flex-end;
   display: flex;
+  white-space: nowrap;
 }
 
 .content {
@@ -40,6 +42,7 @@
   padding-top: 4px;
   padding-bottom: 4px;
   position: relative;
+  word-break: break-word;
 }
 
 .tools {
@@ -130,11 +133,16 @@
       visibility: visible;
     }
   }
+
+  &:has(:global(.avatar):hover) {
+      :global(.link)::before {
+        width: 100%;
+      }
+    }
 }
 
 .username {
   font-weight: bolder;
-  position: relative;
 }
 
 .time {

--- a/src/components/Message/Message.module.scss
+++ b/src/components/Message/Message.module.scss
@@ -19,7 +19,6 @@
   gap: 4px;
   align-items: center;
   padding-right: 8px;
-  max-height: 1rem;
 
   & svg {
     vertical-align: middle;
@@ -135,7 +134,7 @@
   }
 
   &:has(:global(.avatar):hover) {
-      :global(.link)::before {
+      :global(.globalLinkReference)::before {
         width: 100%;
       }
     }

--- a/src/components/Message/MessageHeader.tsx
+++ b/src/components/Message/MessageHeader.tsx
@@ -23,6 +23,7 @@ import { createPortal } from "react-dom";
 import { formatRole } from "@/util/gamemode";
 import { FaTwitch } from "react-icons/fa";
 import animations from "./ChatIconAnimations.module.scss";
+import { Username } from "../Username/Username";
 
 interface IMessageProps {
   message: ThreadMessageDTO;
@@ -149,12 +150,7 @@ export const MessageHeader = observer(function MessageHeader({
       </div>
       <div className={c.contentWrapper__middle}>
         <div className={cx(c.author)}>
-          <PageLink
-            link={AppRouter.players.player.index(message.author.steamId).link}
-            className={cx(c.username, "link")}
-          >
-            {message.author.name}
-          </PageLink>
+          <Username link={AppRouter.players.player.index(message.author.steamId).link}  user={message.author} className={c.username} />
           {roles}
           <span className={c.messageTime}>
             {<PeriodicTimerClient time={message.createdAt} />}

--- a/src/components/Panel/Panel.module.scss
+++ b/src/components/Panel/Panel.module.scss
@@ -18,14 +18,14 @@
     align-items: center;
     justify-content: flex-start;
 
-    & span {
-      //font-size: 1.2rem;
-      //margin-left: 8px;
-    }
+    // & span {
+    //   font-size: 1.2rem;
+    //   margin-left: 8px;
+    // }
 
     & a {
       color: $green;
-      margin-left: 8px;
+      // margin-left: 8px;
       font-size: 1rem;
     }
   }

--- a/src/components/PlayerAvatar/PlayerAvatar.module.scss
+++ b/src/components/PlayerAvatar/PlayerAvatar.module.scss
@@ -7,6 +7,7 @@
 
   //transform: translate(0%, -50%);
   bottom: 0;
+  pointer-events: none;
 }
 
 

--- a/src/components/PlayerAvatar/PlayerAvatar.tsx
+++ b/src/components/PlayerAvatar/PlayerAvatar.tsx
@@ -10,6 +10,8 @@ import c from "./PlayerAvatar.module.scss";
 import { UserDTO } from "@/api/back";
 import cx from "clsx";
 import { hasSubscription } from "@/util/subscription";
+import { PageLink } from "../PageLink/PageLink";
+import { AppRouter, NextLinkProp } from "@/route";
 
 type Props = Omit<
   React.DetailedHTMLProps<
@@ -36,14 +38,17 @@ type Props = Omit<
   objectPosition?: string | undefined;
   lazyBoundary?: string | undefined;
   lazyRoot?: string | undefined;
+  link?: NextLinkProp;
 } & React.RefAttributes<HTMLImageElement | null>;
 
 export const PlayerAvatar: React.FC<Props> = React.memo(function PlayerAvatar({
   user,
+  link,
   ...props
 }: Props) {
   const [error, setError] = useState<unknown>(null);
   const hat = hasSubscription(user) && user.hat?.image.url;
+  const linkProp = link ?? AppRouter.players.player.index(user.steamId).link;
 
   return (
     <picture className={c.avatar}>
@@ -56,13 +61,18 @@ export const PlayerAvatar: React.FC<Props> = React.memo(function PlayerAvatar({
           src={hat}
         />
       )}
-      <Image
-        {...props}
-        className={cx(props.className, "avatar")}
-        alt={props.alt || "Image"}
-        src={error ? "/avatar.png" : user.avatar}
-        onError={setError}
-      />
+      <PageLink
+        link={linkProp}
+      >
+        <Image
+          {...props}
+          className={cx(props.className, "avatar")}
+          alt={props.alt || "Image"}
+          src={error ? "/avatar.png" : user.avatar}
+          onError={setError}
+          title={user.name}
+        />
+      </PageLink>
     </picture>
   );
 });

--- a/src/components/PlayerSummary/PlayerSummary.module.scss
+++ b/src/components/PlayerSummary/PlayerSummary.module.scss
@@ -47,8 +47,11 @@
   align-items: center;
   justify-content: flex-start;
   column-gap: 0.65rem;
-}
 
+  &:hover :global(.globalLinkReference)::before {
+    width: 100%;
+  }
+}
 
 .icons {
   gap: 6px;

--- a/src/components/PlayerSummary/PlayerSummary.module.scss
+++ b/src/components/PlayerSummary/PlayerSummary.module.scss
@@ -30,9 +30,9 @@
 
   margin-left: 0 !important;;
 
-  & svg {
-    //padding: 4px;
-  }
+  // & svg {
+  //   padding: 4px;
+  // }
 }
 
 .twitch {
@@ -46,6 +46,7 @@
   flex-direction: row;
   align-items: center;
   justify-content: flex-start;
+  column-gap: 0.65rem;
 }
 
 
@@ -59,7 +60,6 @@
   flex-direction: row;
   align-items: center;
   font-size: 1.2rem !important;
-  margin-left: 8px;
 }
 
 .tabs {

--- a/src/components/PlayerSummary/PlayerSummary.tsx
+++ b/src/components/PlayerSummary/PlayerSummary.tsx
@@ -30,6 +30,7 @@ import { useStore } from "@/store";
 import { formatBanReason } from "@/util/texts/bans";
 import { hasSubscription } from "@/util/subscription";
 import { formatGameMode } from "@/util/gamemode";
+import { Username } from "../Username/Username";
 
 interface IPlayerSummaryProps {
   className?: string;
@@ -146,13 +147,7 @@ export const PlayerSummary: React.FC<IPlayerSummaryProps> = observer(
                 user={user}
                 alt={`Avatar of player ${name}`}
               />
-              <PageLink
-                className={cx(c.playerName, "link")}
-                link={AppRouter.players.player.index(steamId).link}
-                testId={"player-summary-player-name"}
-              >
-                {steamId.length > 2 ? name : `Бот #${steamId}`}
-              </PageLink>
+              <Username user={user} className={cx(c.playerName, "link")} testId={"player-summary-player-name"} />
             </div>
             <div className={cx(c.player, c.icons)}>
               <a

--- a/src/components/UserPreview/UserPreview.module.scss
+++ b/src/components/UserPreview/UserPreview.module.scss
@@ -4,7 +4,6 @@
   display: flex;
   flex-direction: row;
   align-items: center;
-  width: 100%;
   column-gap: 0.5rem;
   font-size: 0.8rem;
   color: $primaryText;
@@ -14,9 +13,13 @@
   // }
   
   &:has(:global(.avatar):hover) {
-    :global(.link)::before {
+    :global(.globalLinkReference)::before {
       width: 100%;
     }
+  }
+
+  &.block {
+    width: 100%;
   }
 }
 

--- a/src/components/UserPreview/UserPreview.module.scss
+++ b/src/components/UserPreview/UserPreview.module.scss
@@ -4,22 +4,19 @@
   display: flex;
   flex-direction: row;
   align-items: center;
+  width: 100%;
+  column-gap: 0.5rem;
   font-size: 0.8rem;
   color: $primaryText;
-
-  & a,
-  span {
-    display: block;
-    flex: 1;
-    margin-left: 6px;
-    text-transform: capitalize;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-
-  & img {
-    //border-radius: 10%;
+  
+  // & img {
+  //   border-radius: 10%;
+  // }
+  
+  &:has(:global(.avatar):hover) {
+    :global(.link)::before {
+      width: 100%;
+    }
   }
 }
 
@@ -30,12 +27,13 @@
     position: absolute;
     bottom: 4px;
     right: -4px;
-
+    
     width: 10px;
     height: 10px;
     border-radius: 50%;
     background-color: rgba(34, 206, 34, 1);
     outline: 2px solid $bg2;
+    pointer-events: none;
     z-index: 1000;
   }
 }

--- a/src/components/UserPreview/UserPreview.tsx
+++ b/src/components/UserPreview/UserPreview.tsx
@@ -1,14 +1,13 @@
 import React from "react";
-
-import { PageLink, PlayerAvatar } from "..";
-
+import { PlayerAvatar } from "..";
 import c from "./UserPreview.module.scss";
 import { UserDTO } from "@/api/back";
-import { AppRouter, NextLinkProp } from "@/route";
+import { NextLinkProp } from "@/route";
 import { observer } from "mobx-react-lite";
 import { useStore } from "@/store";
 import cx from "clsx";
 import { computed } from "mobx";
+import { Username } from "../Username/Username";
 
 interface IUserPreviewProps {
   user: UserDTO;
@@ -32,27 +31,24 @@ export const UserPreview: React.FC<IUserPreviewProps & DivProps> = observer(
 
     return (
       <div {...props} className={cx(c.user, className)}>
-        <picture
-          className={isOnline ? c.online : undefined}
-          style={{ width: avatarSize || 45, height: avatarSize || 45 }}
-        >
-          <PlayerAvatar
-            width={avatarSize || 45}
-            height={avatarSize || 45}
-            user={user}
-            alt=""
-          />
-        </picture>
-        {nolink ? (
-          <span>{user.name}</span>
-        ) : (
-          <PageLink
-            className={"link"}
-            link={link || AppRouter.players.player.index(user.steamId).link}
+        <div>
+          <picture
+            className={isOnline ? c.online : undefined}
+            style={{ width: avatarSize || 45, height: avatarSize || 45 }}
           >
-            {Number(user.steamId) > 10 ? user.name : "Бот"}
-          </PageLink>
-        )}
+            <PlayerAvatar
+              width={avatarSize || 45}
+              height={avatarSize || 45}
+              user={user}
+              alt=""
+              link={link}
+            />
+          </picture>
+        </div>
+        <Username 
+          user={user} 
+          link={link} 
+          nolink={nolink} />
       </div>
     );
   },

--- a/src/components/UserPreview/UserPreview.tsx
+++ b/src/components/UserPreview/UserPreview.tsx
@@ -15,6 +15,7 @@ interface IUserPreviewProps {
   nolink?: boolean;
   className?: string;
   link?: NextLinkProp;
+  block?: boolean;
 }
 
 type DivProps = React.DetailedHTMLProps<
@@ -23,14 +24,14 @@ type DivProps = React.DetailedHTMLProps<
 >;
 
 export const UserPreview: React.FC<IUserPreviewProps & DivProps> = observer(
-  ({ user, avatarSize, nolink, className, link, ...props }) => {
+  ({ user, avatarSize, nolink, className, link, block, ...props }) => {
     const { queue } = useStore();
     const isOnline = computed(
       () => queue.online.findIndex((x) => x === user.steamId) !== -1,
     ).get();
 
     return (
-      <div {...props} className={cx(c.user, className)}>
+      <div {...props} className={cx(c.user, block ? c.block : undefined, className)}>
         <div>
           <picture
             className={isOnline ? c.online : undefined}
@@ -48,7 +49,8 @@ export const UserPreview: React.FC<IUserPreviewProps & DivProps> = observer(
         <Username 
           user={user} 
           link={link} 
-          nolink={nolink} />
+          nolink={nolink}
+          block={block} />
       </div>
     );
   },

--- a/src/components/Username/Username.module.scss
+++ b/src/components/Username/Username.module.scss
@@ -1,0 +1,33 @@
+@import "../../common.scss";
+
+.linkContainer {
+    display: flex;
+    align-items: center;
+    height: 100%;
+    //40px - размер аватара
+    width: calc(100% - 40px);
+
+    & a {
+        display: flex;
+        align-items: center;
+        padding-top: 0.05rem;
+        height: 100%;
+        width: 100%;
+    }
+}
+
+.usernameLink {
+    display: inline-block; 
+    white-space: nowrap;  
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.usernameWrapper {
+    display: inline-flex; 
+    min-width: 0.5rem;
+}
+
+.linkContainer:hover :global(.link)::before {
+  width: 100%;
+}

--- a/src/components/Username/Username.module.scss
+++ b/src/components/Username/Username.module.scss
@@ -1,17 +1,27 @@
 @import "../../common.scss";
 
-.linkContainer {
+.usernameLinkContainer {
     display: flex;
     align-items: center;
     height: 100%;
-    //40px - размер аватара
-    width: calc(100% - 40px);
+    min-width: 0.5rem;      
+    flex-shrink: 1;  
 
     & a {
         display: flex;
         align-items: center;
         padding-top: 0.05rem;
         height: 100%;
+    }
+    
+    &.block {
+        flex: 1;
+        & a {
+            width: 100%;
+        }
+    }
+
+    &:hover :global(.globalLinkReference)::before {
         width: 100%;
     }
 }
@@ -24,10 +34,7 @@
 }
 
 .usernameWrapper {
-    display: inline-flex; 
+    display: flex;
+    flex-direction: row; 
     min-width: 0.5rem;
-}
-
-.linkContainer:hover :global(.link)::before {
-  width: 100%;
 }

--- a/src/components/Username/Username.tsx
+++ b/src/components/Username/Username.tsx
@@ -11,6 +11,7 @@ interface UsernameProps {
   nolink?: boolean;
   link?: NextLinkProp;
   testId?: string;
+  block?: boolean;
 }
 
 export const Username: React.FC<UsernameProps> = ({
@@ -19,6 +20,7 @@ export const Username: React.FC<UsernameProps> = ({
   nolink,
   link,
   testId,
+  block,
 }) => {
   const targetLink = link ?? AppRouter.players.player.index(user.steamId).link;
   const displayName =
@@ -31,9 +33,9 @@ export const Username: React.FC<UsernameProps> = ({
   }
 
   return (
-    <div className={c.linkContainer} title={user.name}>
+    <div className={cx(c.usernameLinkContainer, block ? c.block : undefined)} title={user.name}>
         <PageLink link={targetLink} testId={testId}>
-            <span className={cx(c.usernameWrapper, "link")}>
+            <span className={cx(c.usernameWrapper, "link", "globalLinkReference")}>
                 <span className={cx(c.usernameLink, className)}>
                     {displayName}
                 </span>

--- a/src/components/Username/Username.tsx
+++ b/src/components/Username/Username.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { PageLink } from "../PageLink/PageLink";
+import { AppRouter, NextLinkProp } from "@/route";
+import cx from "clsx";
+import c from "./Username.module.scss";
+import { UserDTO } from "@/api/back";
+
+interface UsernameProps {
+  user: UserDTO;
+  className?: string;
+  nolink?: boolean;
+  link?: NextLinkProp;
+  testId?: string;
+}
+
+export const Username: React.FC<UsernameProps> = ({
+  user,
+  className,
+  nolink,
+  link,
+  testId,
+}) => {
+  const targetLink = link ?? AppRouter.players.player.index(user.steamId).link;
+  const displayName =
+    Number(user.steamId) > 10
+      ? user.name?.trim() || '<blank>'
+      : `Бот #${user.steamId}`;
+
+  if (nolink) {
+    return <span className={cx(c.username, className)}>{displayName}</span>;
+  }
+
+  return (
+    <div className={c.linkContainer} title={user.name}>
+        <PageLink link={targetLink} testId={testId}>
+            <span className={cx(c.usernameWrapper, "link")}>
+                <span className={cx(c.usernameLink, className)}>
+                    {displayName}
+                </span>
+            </span>
+        </PageLink>
+    </div>
+  );
+};

--- a/src/containers/MatchPageContainer/MatchPageContainer.tsx
+++ b/src/containers/MatchPageContainer/MatchPageContainer.tsx
@@ -116,6 +116,45 @@ export const MatchPageContainer: React.FC<IMatchPageContainerProps> = observer(
     const [filter, setFilter] = useState<Filter>(options[0]);
 
     if (match) {
+
+      const allPlayers: PlayerInMatchDto[] = useMemo(
+        () => [...match.radiant, ...match.dire],
+        [match.radiant, match.dire]
+      );
+
+      const globalMaxValues = useMemo(() => {
+        const mx: Record<string, number> = {
+          gpm: 0,
+          xpm: 0,
+          lastHits: 0,
+          denies: 0,
+          kills: 0,
+          deaths: 0,
+          assists: 0,
+          heroDamage: 0,
+          heroHealing: 0,
+          towerDamage: 0,
+          gold: 0,
+        };
+        for (const p of allPlayers) {
+          mx.gpm = Math.max(mx.gpm, p.gpm);
+          mx.xpm = Math.max(mx.xpm, p.xpm);
+          mx.lastHits = Math.max(mx.lastHits, p.lastHits);
+          mx.denies = Math.max(mx.denies, p.denies);
+          mx.kills = Math.max(mx.kills, p.kills);
+          mx.deaths = Math.max(mx.deaths, p.deaths);
+          mx.assists = Math.max(mx.assists, p.assists);
+          mx.heroDamage = Math.max(mx.heroDamage, p.heroDamage);
+          mx.heroHealing = Math.max(mx.heroHealing, p.heroHealing);
+          mx.towerDamage = Math.max(mx.towerDamage, p.towerDamage);
+          const goldValue = Math.round(
+            p.gold || Math.round((p.gpm * match.duration) / 60) * 0.6
+          );
+          mx.gold = Math.max(mx.gold, goldValue);
+        }
+        return mx;
+      }, [allPlayers, match.duration]);
+
       return (
         <>
           {feedbackData && (
@@ -159,6 +198,7 @@ export const MatchPageContainer: React.FC<IMatchPageContainerProps> = observer(
             reportableSteamIds={reportableSteamIds}
             filterColumns={filter.columns}
             duration={match.duration}
+            globalMaxValues={globalMaxValues}
             players={match.radiant}
           />
           <br />
@@ -178,6 +218,7 @@ export const MatchPageContainer: React.FC<IMatchPageContainerProps> = observer(
             reportableSteamIds={reportableSteamIds}
             filterColumns={filter.columns}
             duration={match.duration}
+            globalMaxValues={globalMaxValues}
             players={match.dire}
           />
 

--- a/src/pages/heroes/[hero]/index.tsx
+++ b/src/pages/heroes/[hero]/index.tsx
@@ -67,7 +67,7 @@ export default function HeroHistoryPage({
             Показать еще
           </PageLink>
         </header>
-        <HeroWithItemsHistoryTable loading={false} data={formattedMatches} />
+        <HeroWithItemsHistoryTable loading={false} data={formattedMatches} showUser />
       </Section>
       <Section className={c.items}>
         <header>Лучшие игроки</header>

--- a/src/pages/heroes/[hero]/matches.tsx
+++ b/src/pages/heroes/[hero]/matches.tsx
@@ -65,6 +65,7 @@ export default function HeroMatches({
           withItems
           loading={isLoading}
           data={formattedMatches}
+          showUser
         />
         <Pagination
           linkProducer={(page) =>

--- a/src/pages/wiki/Wiki.module.scss
+++ b/src/pages/wiki/Wiki.module.scss
@@ -1,8 +1,8 @@
 @import "../../common.scss";
 
-.container {
-}
-
 .iframe {
-  height: 100vh;
+  box-shadow: none;
+  overflow: hidden;
+  overflow-anchor: none;
+  // transition: height 0.500s ease;
 }

--- a/src/pages/wiki/index.tsx
+++ b/src/pages/wiki/index.tsx
@@ -1,7 +1,39 @@
-import c from "./Wiki.module.scss";
+import React, { useRef, useEffect } from 'react';
+import c from './Wiki.module.scss';
+
+//ни в коем случае не ставить в конце слэш
+const CHILD_ORIGIN = "https://wiki.dotaclassic.ru";
 
 export default function WikiEmbed() {
+  const iframeRef = useRef<HTMLIFrameElement | null>(null);
+
+  useEffect(() => {
+    function handleMessage(event: MessageEvent) {
+      if (event.origin !== CHILD_ORIGIN) return;
+
+      const data = event.data as { type: string };
+      if (data.type === 'setHeight' && typeof (event.data as any).height === 'number') {
+        iframeRef.current!.style.height = `${(event.data as any).height}px`;
+      }
+      else if (data.type === 'scrollToTopDefault') {
+        iframeRef.current!.scrollIntoView({ behavior: 'auto', block: 'start' });
+      }
+      // else if (data.type === 'scrollToTopSmooth') {
+      //   setTimeout(() => {
+      //     iframeRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start'});
+      //   }, 25);
+      // }
+    }
+
+    window.addEventListener('message', handleMessage);
+    return () => window.removeEventListener('message', handleMessage);
+  }, []);
+
   return (
-    <iframe src="https://wiki.dotaclassic.ru" className={c.iframe}></iframe>
+    <iframe
+      ref={iframeRef}
+      src={CHILD_ORIGIN}
+      className={c.iframe}
+    />
   );
 }

--- a/src/util/mappers.ts
+++ b/src/util/mappers.ts
@@ -24,5 +24,6 @@ export const matchToPlayerMatchItem = (
     item3: thisPlayer.item3,
     item4: thisPlayer.item4,
     item5: thisPlayer.item5,
+    user: thisPlayer.user
   };
 };


### PR DESCRIPTION
✅ Исправлено отображение ролей рядом с Username. Username и UserPreview: для табличных сценариев (где не отображаются роли) добавлено свойство block, чтобы компонент занимал всю горизонталь (для корректного использования в компоненте-родителе нужно делать обертку с фиксированной длиной). 
✅ Добавлены обертки для корректного отображения длинных ников в LiveMatchPreview и MatchTeamTable
✅ Небольшие правки для корректного отображения названий предметов в таблице предметов (GenericTable)